### PR TITLE
Interested in Meson building for this repo?

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ If you also want to try k-mer comparision plot, run the following commands to in
 git clone https://github.com/dfguan/KMC.git 
 cd KMC && make -j 16
 ```
+
+### Installation using Meson/Ninja
+
+PREFIX_ARG?=/usr/local
+
+cd purge_dups/src
+mkdir build && meson --prefix ${PREFIX_ARG} --buildtype release build .
+ninja -C build install
+
 ## <a name="usg"> </a> Usage (Only tested on farm)
 
 ### Step 1. Use pd\_config.py to generate a configuration file. 

--- a/src/get_seqs.c
+++ b/src/get_seqs.c
@@ -16,6 +16,7 @@
  * =====================================================================================
  */
 #include <stdio.h>
+#include <unistd.h>
 #include <zlib.h>
 
 #include "sdict.h"

--- a/src/meson.build
+++ b/src/meson.build
@@ -49,7 +49,7 @@ if not meson.is_subproject()
     c_args : cflags,
   )
   executable(
-    'calcuts',
+    'purge_dups_calcuts',
     files([
         'calcuts.c',
     ]),
@@ -59,7 +59,7 @@ if not meson.is_subproject()
     c_args : cflags,
   )
   executable(
-    'get_seqs',
+    'purge_dups_get_seqs',
     files([
         'get_seqs.c',
     ]),
@@ -69,7 +69,7 @@ if not meson.is_subproject()
     c_args : cflags,
   )
   executable(
-    'ngscstat',
+    'purge_dups_ngscstat',
     files([
         'ngscstat.c',
     ]),
@@ -79,7 +79,7 @@ if not meson.is_subproject()
     c_args : cflags,
   )
   executable(
-    'pbcstat',
+    'purge_dups_pbcstat',
     files([
         'pbcstat.c',
     ]),
@@ -89,7 +89,7 @@ if not meson.is_subproject()
     c_args : cflags,
   )
   executable(
-    'split_fa',
+    'purge_dups_split_fa',
     files([
         'split_fa.c',
     ]),

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,106 @@
+# We cannot yet use c_std=c11 because of these errors:
+#   get_seqs.c:357:17: error: 'optarg' undeclared
+#   get_seqs.c:392:6: error: 'optind' undeclared
+# We need to include <unistd.h>
+
+project(
+  'purge_dups',
+  ['c'],
+  version : '1.0.1',
+  default_options : [
+    'buildtype=release',
+    'warning_level=3',
+    #'c_std=c11',
+    'b_ndebug=if-release'],
+  license : 'MIT',
+  meson_version : '>= 0.46.0')
+
+cflags = '-Wall'
+
+# libm
+cc = meson.get_compiler('c')
+m_dep = cc.find_library('m', required : true)
+
+# libz
+zlib_dep = dependency('zlib', required : true)
+
+lib_deps = [zlib_dep, m_dep]
+
+c_sources = files([
+    'asset.c',
+    'bamlite.c',
+    'cov.c',
+    'opt.c',
+    'paf.c',
+    'sdict.c',
+])
+
+lib = static_library(
+  'purge_dups_lib',
+  c_sources,
+  dependencies : lib_deps,
+  c_args : cflags)
+
+if not meson.is_subproject()
+  executable(
+    'purge_dups',
+    files([
+        'purge_dups.c',
+    ]),
+    install : true,
+    dependencies : lib_deps,
+    link_with : lib,
+    #include_directories : ['.'],
+    c_args : cflags,
+  )
+  executable(
+    'calcuts',
+    files([
+        'calcuts.c',
+    ]),
+    install : true,
+    dependencies : lib_deps,
+    link_with : lib,
+    c_args : cflags,
+  )
+  executable(
+    'get_seqs',
+    files([
+        'get_seqs.c',
+    ]),
+    install : true,
+    dependencies : lib_deps,
+    link_with : lib,
+    c_args : cflags,
+  )
+  executable(
+    'ngscstat',
+    files([
+        'ngscstat.c',
+    ]),
+    install : true,
+    dependencies : lib_deps,
+    link_with : lib,
+    c_args : cflags,
+  )
+  executable(
+    'pbcstat',
+    files([
+        'pbcstat.c',
+    ]),
+    install : true,
+    dependencies : lib_deps,
+    link_with : lib,
+    c_args : cflags,
+  )
+  executable(
+    'split_fa',
+    files([
+        'split_fa.c',
+    ]),
+    install : true,
+    dependencies : lib_deps,
+    link_with : lib,
+    c_args : cflags,
+  )
+endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,8 +1,3 @@
-# We cannot yet use c_std=c11 because of these errors:
-#   get_seqs.c:357:17: error: 'optarg' undeclared
-#   get_seqs.c:392:6: error: 'optind' undeclared
-# We need to include <unistd.h>
-
 project(
   'purge_dups',
   ['c'],
@@ -10,7 +5,7 @@ project(
   default_options : [
     'buildtype=release',
     'warning_level=3',
-    #'c_std=c11',
+    'c_std=c11',
     'b_ndebug=if-release'],
   license : 'MIT',
   meson_version : '>= 0.46.0')


### PR DESCRIPTION
Hello,

We would like to use `purge_dups` in a workflow at Pacific Biosciences, but we have an integration problem. We something find **zlib** via `pkg-config` and we sometimes use the system `zlib.so`. We like to let **meson** detect `pkg-config` when available.

Here is a `meson.build` file that we would like included in this repository. We could use it separately, but it's easier for us if it lives here.

I've also included a small fix for ISO C 2011, which lets us specify `c_std=c11` in `meson.build`.

We also would like to prefix your executables with a unique namespace, in case anybody else writes something called `get_seqs` or `split_fa`. For now, that change is only in `meson.build` to avoid breaking any existing workflows.

To learn more about **Meson** and **Ninja**, see:
* https://mesonbuild.com/
* https://ninja-build.org/